### PR TITLE
correct typo in the assignment of TF_VAR_db_password env variable

### DIFF
--- a/infra/deploy/variables.tf
+++ b/infra/deploy/variables.tf
@@ -21,7 +21,7 @@ variable "db_username" {
 
 variable "db_password" {
   description = "password for recipe app api database"
-
+  
 }
 
 

--- a/infra/deploy/variables.tf
+++ b/infra/deploy/variables.tf
@@ -21,7 +21,7 @@ variable "db_username" {
 
 variable "db_password" {
   description = "password for recipe app api database"
-  
+
 }
 
 

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -12,5 +12,5 @@ services:
       - AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN}
       - AWS_DEFAULT_REGION=us-east-1
       - TF_WORKSPACE=${TF_WORKSPACE}
-      - TF_VAR_db_password:${TF_VAR_db_password}
+      - TF_VAR_db_password=${TF_VAR_db_password}
 


### PR DESCRIPTION
correct typo in the assignment of TF_VAR_db_password env variable